### PR TITLE
added the new role for sync

### DIFF
--- a/configs/service/config.json
+++ b/configs/service/config.json
@@ -97,7 +97,8 @@
     "📖": "book-club",
     "👽": "cyber-sec",
     "👶": "practice-programming-beginner",
-    "📏": "data-engineer"
+    "📏": "data-engineer",
+    "🧡": "eng-management"
   },
   "startUpCorrelatation": false,
   "syncPeriod": 300000,


### PR DESCRIPTION
This is the new role defined for eng-management track. We want this group tp be added in sync
Google Workspace group is already created and Discord group as well. 